### PR TITLE
Clarify README and Remove form_fors

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ forms. Take a look at what's happening in the partial `_form.html.erb` for
 users, which was created when we used Rails's scaffold generator:
 
 ```erb
-<%= form_for(@user) do |f| %>
+<%= form_with(model: @user, local: true) do |f| %>
   <% if @user.errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(@user.errors.count, "error") %> prohibited this user from being saved:</h2>

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ have).
    [generators](http://api.rubyonrails.org/classes/Rails/Generators.html), and remember to skip adding tests.
    * `users` and `tags` both only have a `name` column.
 3. In order to create the appropriate associations between `Post` and `Tag`, we
-   need to create a join table as well.
+   need to create a join table and model.
 4. Build out model associations and migrations.
    * Posts should *OPTIONALLY* belong to a user
 5. Be sure to create the appropriate routes. For now, they can be written as

--- a/README.md
+++ b/README.md
@@ -17,15 +17,15 @@ have).
 
 ## Migrations, Associations, and Routes
 
-1. Change the migration for `posts` to include `content` (set `content`'s
-   datatype to `text` to account for character length).
+1. Change the migration for `posts` to include `content` with a datatype of `text`.
 2. Create a migration, model, and optionally controller for `User` and `Tag`
    (via `rails generate`). Check out the documentation on
-   [generators](http://api.rubyonrails.org/classes/Rails/Generators.html), and
-   remember to skip adding tests.
+   [generators](http://api.rubyonrails.org/classes/Rails/Generators.html), and remember to skip adding tests.
+   * `users` and `tags` both only have a `name` column.
 3. In order to create the appropriate associations between `Post` and `Tag`, we
    need to create a join table as well.
 4. Build out model associations and migrations.
+   * Posts should *OPTIONALLY* belong to a user
 5. Be sure to create the appropriate routes. For now, they can be written as
    `resources`.
 6. `create` the database, `migrate` the schema, and `seed` it.

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,21 +1,18 @@
-<%= form_for(@post) do |f| %>
+<%= form_with(model: @post, local: true) do |f| %>
   <% if @post.errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(@post.errors.count, "error") %> prohibited this post from being saved:</h2>
-
       <ul>
-      <% @post.errors.full_messages.each do |msg| %>
-        <li><%= msg %></li>
-      <% end %>
+        <% @post.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
       </ul>
     </div>
   <% end %>
-
   <div class="field">
     <%= f.label :name %><br>
     <%= f.text_field :name %><br>
   </div>
-
   <div class="actions">
     <%= f.submit %>
   </div>


### PR DESCRIPTION
This pull request updates the documentation and form usage to modern Rails conventions and clarifies the requirements for migrations and associations. The most important changes are grouped below:

**Documentation and Requirements Improvements:**

* Clarified the instructions in `README.md` for creating migrations and models, specifying that both `users` and `tags` should only have a `name` column, and that a join table and model are needed for the association between `Post` and `Tag`. Also noted that posts should optionally belong to a user.

**Form Helper Modernization:**

* Updated form helpers in both `app/views/posts/_form.html.erb` and the example in `README.md` to use `form_with` instead of the deprecated `form_for`, following current Rails best practices. [[1]](diffhunk://#diff-1f04c40d9475dca0e5ddc8423a10f452474f36a64e774718791a6766828899c5L1-L18) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L53-R53)